### PR TITLE
Remove recipient field from transaction details page

### DIFF
--- a/apps/explorer/src/app/pages/transaction/transaction.component.html
+++ b/apps/explorer/src/app/pages/transaction/transaction.component.html
@@ -20,7 +20,7 @@
                   | lto_amount}}</poe-keyvalue-list-item>
                 <poe-keyvalue-list-item label="Fee">{{transaction.fee | lto_amount}}</poe-keyvalue-list-item>
                 <poe-keyvalue-list-item label="Sender"><a [routerLink]="['/', 'address', transaction.sender]">{{transaction.sender}}</a></poe-keyvalue-list-item>
-                <poe-keyvalue-list-item label="Recipient"><a [routerLink]="['/', 'address', transaction.recipient]">{{transaction.recipient}}</a></poe-keyvalue-list-item>
+                <poe-keyvalue-list-item *ngIf="transaction.type !== 12" label="Recipient"><a [routerLink]="['/', 'address', transaction.recipient]">{{transaction.recipient}}</a></poe-keyvalue-list-item>
                 <poe-keyvalue-list-item label="Signature">{{transaction.signature}}</poe-keyvalue-list-item>
               </poe-keyvalue-list>
             </ng-container>

--- a/apps/explorer/src/app/pages/transaction/transaction.component.html
+++ b/apps/explorer/src/app/pages/transaction/transaction.component.html
@@ -20,7 +20,7 @@
                   | lto_amount}}</poe-keyvalue-list-item>
                 <poe-keyvalue-list-item label="Fee">{{transaction.fee | lto_amount}}</poe-keyvalue-list-item>
                 <poe-keyvalue-list-item label="Sender"><a [routerLink]="['/', 'address', transaction.sender]">{{transaction.sender}}</a></poe-keyvalue-list-item>
-                <poe-keyvalue-list-item *ngIf="transaction.type !== 12" label="Recipient"><a [routerLink]="['/', 'address', transaction.recipient]">{{transaction.recipient}}</a></poe-keyvalue-list-item>
+                <poe-keyvalue-list-item *ngIf="showRecipient(transaction)" label="Recipient"><a [routerLink]="['/', 'address', transaction.recipient]">{{transaction.recipient}}</a></poe-keyvalue-list-item>
                 <poe-keyvalue-list-item label="Signature">{{transaction.signature}}</poe-keyvalue-list-item>
               </poe-keyvalue-list>
             </ng-container>

--- a/apps/explorer/src/app/pages/transaction/transaction.component.ts
+++ b/apps/explorer/src/app/pages/transaction/transaction.component.ts
@@ -25,4 +25,9 @@ export class TransactionComponent implements OnInit {
   }
 
   ngOnInit() {}
+
+  showRecipient(transaction: { type: number }): boolean {
+    // Hide recipient for data/anchor transactions
+    return transaction.type !== 12 && transaction.type !== 15;
+  }
 }


### PR DESCRIPTION
Remove recipient field from transaction details page for data transactions (type 12).

Closes #7 