### PR TITLE
take active lease from dedicated endpoint

### DIFF
--- a/apps/wallet/src/app/core/services/lto-public-node.service.ts
+++ b/apps/wallet/src/app/core/services/lto-public-node.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, ClassProvider } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, timer } from 'rxjs';
-import { map, switchMap, switchMapTo, distinctUntilChanged } from 'rxjs/operators';
+import { map, switchMap, switchMapTo, distinctUntilChanged, catchError } from 'rxjs/operators';
 import { LTO_PUBLIC_API } from '../../tokens';
 
 /**
@@ -86,6 +86,10 @@ export class LtoPublicNodeServiceImpl implements LtoPublicNodeService {
   unconfirmedTransactions(): Observable<any[]> {
     return this._http.get<any>(this._publicApi + 'transactions/unconfirmed');
   }
+
+  activeLease(address: string): Observable<LTO.Transaction[]> {
+    return this._http.get<LTO.Transaction[]>(`${this._publicApi}leasing/active/${address}`);
+  }
 }
 
 export abstract class LtoPublicNodeService {
@@ -108,4 +112,5 @@ export abstract class LtoPublicNodeService {
   ): Observable<LTO.Page<LTO.Transaction>>;
   abstract balanceOf(address: string): Observable<any>;
   abstract unconfirmedTransactions(): Observable<any[]>;
+  abstract activeLease(address: string): Observable<LTO.Transaction[]>;
 }

--- a/apps/wallet/src/app/core/services/wallet.service.ts
+++ b/apps/wallet/src/app/core/services/wallet.service.ts
@@ -155,10 +155,6 @@ export class WalletServiceImpl implements WalletService {
       })
     );
 
-    // this.leasingTransactions$ = this.transactions$.pipe(
-    //   map(transactionsFilter(TransactionTypes.LEASING, TransactionTypes.CANCEL_LEASING))
-    // );
-
     this.dataTransactions$ = this.transactions$.pipe(
       map(transactionsFilter(TransactionTypes.ANCHOR))
     );

--- a/apps/wallet/src/app/lto.d.ts
+++ b/apps/wallet/src/app/lto.d.ts
@@ -4,6 +4,11 @@ declare namespace LTO {
     sender: string;
     type: number;
     fee: number;
+    /**
+     * Lease specific field. We need to keep it here because our endpoint
+     * returns all transactions mixed
+     */
+    status?: 'active' | 'canceled';
 
     [key: string]: any;
   }


### PR DESCRIPTION
Take active lease from `${this._publicApi}leasing/active/${address}`. Keep all other logic as it used to be before.