### PR TITLE
Don't show new wallet address when creating an account.

### DIFF
--- a/apps/wallet/src/app/create-account/create-account.component.html
+++ b/apps/wallet/src/app/create-account/create-account.component.html
@@ -14,7 +14,6 @@
 <ng-template #step1Tpl>
   <div class="step-1 narrow">
     <p>We will generate a random account address for you</p>
-    <lto-copyable-text [text]="wallet.address"></lto-copyable-text>
   </div>
   <div class="buttons">
     <div class="narrow">


### PR DESCRIPTION
Don't show new wallet address when creating an account. Naive users may copy the address and share it when requesting tokens. If they don't complete creating the account, tokens send to this address will be lost forever.

![screenshot-wallet lto network-2019 05 27-17-20-36](https://user-images.githubusercontent.com/100821/58428739-c256be00-80a3-11e9-83b5-4ae6372fdc83.png)
